### PR TITLE
Add type stubs for Squirrel VM bindings

### DIFF
--- a/squirrel-lang/squirrel/__init__.pyi
+++ b/squirrel-lang/squirrel/__init__.pyi
@@ -1,0 +1,42 @@
+from typing import Any, Callable
+
+__version__: str
+__author__: str
+
+
+class StaticVM:
+    vm: Any
+
+    def bindfunc(
+        self,
+        funcname: str,
+        func: Callable,
+        withenv: bool = False
+    ) -> None:
+        ...
+
+
+class tagSQObjectType:
+    ...
+
+
+class tagSQObjectValue:
+    ...
+
+
+SQVM: Callable[..., StaticVM]
+get_static_vm: Callable[..., Any]
+
+
+def compile(
+    sourcecode: str,
+    sourcename: str = "__main__"
+) -> bytes:
+    ...
+
+
+def compile_bb(
+    sourcecode: str,
+    sourcename: str = "__main__"
+) -> bytes:
+    ...


### PR DESCRIPTION
## Description

### Summary

This PR adds a `__init__.pyi` type stub file to improve static typing support for `squirrel-py`.

It defines core Squirrel VM interfaces and function signatures, enabling better autocomplete, type checking, and IDE integration for developers working with the binding layer.

---

### Changes

* Added `StaticVM` class type definition with `bindfunc` method signature
* Declared `SQVM` factory callable returning `StaticVM`
* Added stubs for:

  * `get_static_vm`
  * `compile`
  * `compile_bb`
* Defined placeholder structures for:

  * `tagSQObjectType`
  * `tagSQObjectValue`
* Added package metadata fields:

  * `__version__`
  * `__author__`

---

### Why this matters

This improves developer experience by:

* Enabling static type checkers (mypy, pyright) to understand the API
* Improving autocomplete in VS Code and other IDEs
* Making the Squirrel VM binding layer more predictable and self-documenting

---

### Notes

* This is a `.pyi` stub only and does not affect runtime behavior
* All implementations remain in the existing `.py` module
* No functional changes introduced