### PR TITLE
Fix setup.py CMake pybind11 path lookup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,14 @@ class CMakeBuild(build_ext):
         # In this example, we pass in the version to C++. You might not need to.
         cmake_args += [f"-DVERSION_INFO={__version__}"]
 
+        try:
+            import pybind11  # type: ignore
+        except ImportError:
+            pybind11_dir = None
+        else:
+            pybind11_dir = pybind11.get_cmake_dir()
+            cmake_args += [f"-Dpybind11_DIR={pybind11_dir}"]
+
         if self.compiler.compiler_type != "msvc":
             # Using Ninja-build since it a) is available as a wheel and b)
             # multithreads automatically. MSVC would require all variables be


### PR DESCRIPTION
This patch updates setup.py so the build passes the installed pybind11 CMake directory into CMake, allowing find_package(pybind11 CONFIG) and pybind11_add_module to work during python3 setup.py build.